### PR TITLE
App using rm -rf that was unspotted so far ... to be reported as error by the linter

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -68,9 +68,9 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]; then
 	ynh_setup_source --dest_dir="$tmpdir"
 	## clean & copy files needed to final folder
 	myynh_clean_source
-	[ -e "$tmpdir/config.php" ] && rm "$tmpdir/config.php"
+	[ -e "$tmpdir/config.php" ] && ynh_secure_remove "$tmpdir/config.php"
 	cp -a "$tmpdir/." "$final_path"
-	rm -R "$tmpdir"
+	ynh_secure_remove "$tmpdir"
 	## set permissions
 	myynh_set_permissions
 fi


### PR DESCRIPTION
c.f. https://github.com/YunoHost/package_linter/commit/4b513b4cd67275dfc597d30ddbfe1801293ad15a#diff-661c3b5fe67e77caea903b5fdb903b5fb6e8277c912d4a4af94e179ade2910baR1019

This app is using some `rm -rf` or similar command that was unspotted so far ... The app is gonna be capped to level 4 by the CI until this is fixed :/ 