### PR TITLE
Moar cleanup

### DIFF
--- a/check_process
+++ b/check_process
@@ -20,26 +20,8 @@
 		upgrade=1	from_commit=03e787291ba1104f195fdeb5103071b9546b4ad5
 		backup_restore=1
 		multi_instance=0
-		wrong_user=1
-		wrong_path=1
-		incorrect_path=1
-		corrupt_source=1
-		fail_download_source=1
 		port_already_use=0
-		final_path_already_use=1
 		change_url=1
-;;; Levels
-	Level 1=auto
-	Level 2=auto
-	Level 3=auto
-	# Level 4: No ldap support (https://github.com/broncowdd/BoZoN/issues/197)
-	Level 4=na
-	Level 5=auto
-	Level 6=auto
-	Level 7=auto
-	Level 8=0
-	Level 9=0
-	Level 10=0
 ;;; Options
 Email=
 Notification=none

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -22,22 +22,10 @@ myynh_create_dir () {
 	[ -d "$1" ] || mkdir -p "$1"
 }
 
-# Check if enough disk space available on backup storage
-myynh_check_disk_space () {
-	file_to_analyse=$1
-	backup_size=$(du --summarize "$1" | cut -f1)
-	free_space=$(df --output=avail "/home/yunohost.backup" | sed 1d)
-	if [ $free_space -le $backup_size ]; then
-		WARNING echo "Not enough backup disk space for: $1"
-		WARNING echo "Space available: $(HUMAN_SIZE $free_space)"
-		ynh_die --message="Space needed: $(HUMAN_SIZE $backup_size)"
-	fi
-}
-
 # Clean & copy files needed to final folder
 myynh_clean_source () {
 	find "$tmpdir" -type f -name ".htaccess" | xargs rm
-	[ -e "$tmpdir/.gitignore" ] && rm -r "$tmpdir/.gitignore"
+	[ -e "$tmpdir/.gitignore" ] && ynh_secure_remove "$tmpdir/.gitignore"
 }
 
 myynh_set_permissions () {

--- a/scripts/backup
+++ b/scripts/backup
@@ -21,7 +21,7 @@ ynh_abort_if_errors
 #=================================================
 # LOAD SETTINGS
 #=================================================
-ynh_script_progression --message="Loading installation settings..." --time --weight=1
+ynh_script_progression --message="Loading installation settings..."
 app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get --app="$app" --key=domain)
 final_path=$(ynh_app_setting_get --app="$app" --key=final_path)
@@ -32,21 +32,20 @@ data_path=$(ynh_app_setting_get --app="$app" --key=data_path)
 #=================================================
 # BACKUP THE APP MAIN DIR
 #=================================================
-ynh_script_progression --message="Backing up the main app directory..." --time --weight=1
+ynh_script_progression --message="Backing up the main app directory..."
 if [ -e "$final_path" ]; then
-	myynh_check_disk_space "$final_path"
 	ynh_backup --src_path="$final_path"
 fi
 #=================================================
 # BACKUP THE NGINX CONFIGURATION
 #=================================================
-ynh_script_progression --message="Backing up nginx web server configuration..." --time --weight=1
+ynh_script_progression --message="Backing up nginx web server configuration..."
 ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 
 #=================================================
 # BACKUP THE PHP-FPM CONFIGURATION
 #=================================================
-ynh_script_progression --message="Backing up php-fpm configuration..." --time --weight=1
+ynh_script_progression --message="Backing up php-fpm configuration..."
 ynh_backup --src_path="/etc/php/7.0/fpm/pool.d/$app.conf"
 
 ##=================================================
@@ -58,7 +57,6 @@ ynh_script_progression --message="Backing up data directory..."
 if [ -e "$data_path" ]; then
 	backup_core_only=$(ynh_app_setting_get "$app" backup_core_only)
 	if [ $backup_core_only -eq 0 ]; then
-		myynh_check_disk_space "$data_path"
 		ynh_backup --src_path="$data_path" --is_big
 	else
 		echo "Data dir will not be saved, because backup_core_only is set to true." >&2

--- a/scripts/remove
+++ b/scripts/remove
@@ -13,47 +13,36 @@ source /usr/share/yunohost/helpers
 #=================================================
 # LOAD SETTINGS
 #=================================================
-ynh_script_progression --message="Loading installation settings..." --time --weight=1
+ynh_script_progression --message="Loading installation settings..." --weight=1
 app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get --app="$app" --key=domain)
 final_path=$(ynh_app_setting_get --app="$app" --key=final_path)
 data_path=$(ynh_app_setting_get --app="$app" --key=data_path)
 
 #=================================================
-# BACKUP OF APP AND DATAS
-#=================================================
-ynh_script_progression --message="Backing up app and datas..." --time --weight=3
-if [ $(yunohost app list -i -f "$app" | wc -l) -gt 1 ]; then
-	ynh_app_setting_set --app="$app" --key=backup_core_only --value=0
-	app_bck=${app//_/-}
-	yunohost backup create --apps "$app" --name "${app_bck}_$(date '+%Y%m%d-%H%M%S')"
-	echo "BoZon fully backuped." >&2
-fi
-
-#=================================================
 # STANDARD REMOVE
 #=================================================
 # REMOVE DEPENDENCIES
 #=================================================
-ynh_script_progression --message="Removing dependencies..." --time --weight=1
+ynh_script_progression --message="Removing dependencies..." --weight=1
 ynh_remove_app_dependencies
 
 #=================================================
 # REMOVE APP MAIN DIR
 #=================================================
-ynh_script_progression --message="Removing app main directory..." --time --weight=1
+ynh_script_progression --message="Removing app main directory..." --weight=1
 ynh_secure_remove --file="$final_path"
 
 #=================================================
 # REMOVE NGINX CONFIGURATION
 #=================================================
-ynh_script_progression --message="Removing nginx web server configuration..." --time --weight=1
+ynh_script_progression --message="Removing nginx web server configuration..." --weight=1
 ynh_remove_nginx_config
 
 #=================================================
 # REMOVE PHP-FPM CONFIGURATION
 #=================================================
-ynh_script_progression --message="Removing php-fpm configuration..." --time --weight=1
+ynh_script_progression --message="Removing php-fpm configuration..." --weight=1
 ynh_remove_fpm_config
 
 #=================================================
@@ -66,10 +55,10 @@ ynh_secure_remove --file="$data_path"
 #=================================================
 # REMOVE DEDICATED USER
 #=================================================
-ynh_script_progression --message="Removing the dedicated system user..." --time --weight=1
+ynh_script_progression --message="Removing the dedicated system user..." --weight=1
 ynh_system_user_delete --username="$app"
 
 #=================================================
 # END OF SCRIPT
 #=================================================
-ynh_script_progression --message="Removal of $app completed" --time --last
+ynh_script_progression --message="Removal of $app completed" --last

--- a/scripts/restore
+++ b/scripts/restore
@@ -22,7 +22,7 @@ ynh_abort_if_errors
 #=================================================
 # LOAD SETTINGS
 #=================================================
-ynh_script_progression --message="Loading installation settings..." --time --weight=1
+ynh_script_progression --message="Loading installation settings..." --weight=1
 app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get --app="$app" --key=domain)
 path_url=$(ynh_app_setting_get --app="$app" --key=path)
@@ -33,7 +33,7 @@ data_path=$(ynh_app_setting_get --app="$app" --key=data_path)
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED
 #=================================================
-ynh_script_progression --message="Validating restoration parameters..." --time --weight=1
+ynh_script_progression --message="Validating restoration parameters..." --weight=1
 ynh_webpath_available --domain="$domain" --path_url="$path_url" || ynh_die --message="Path not available: ${domain}${path_url}"
 test ! -d $final_path || ynh_die --message="There is already a directory: $final_path"
 
@@ -47,13 +47,13 @@ ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 # RESTORE THE APP MAIN DIR
 #=================================================
-ynh_script_progression --message="Restoring the app main directory..." --time --weight=1
+ynh_script_progression --message="Restoring the app main directory..." --weight=1
 ynh_restore_file --origin_path="$final_path"
 
 #=================================================
 # RECREATE THE DEDICATED USER
 #=================================================
-ynh_script_progression --message="Recreating the dedicated system user..." --time --weight=1
+ynh_script_progression --message="Recreating the dedicated system user..." --weight=1
 ynh_system_user_create --username="$app"
 
 #=================================================
@@ -66,13 +66,13 @@ ynh_restore_file --origin_path="/etc/php/7.0/fpm/pool.d/$app.conf"
 #=================================================
 # REINSTALL DEPENDENCIES
 #=================================================
-ynh_script_progression --message="Reinstalling dependencies..." --time --weight=1
+ynh_script_progression --message="Reinstalling dependencies..." --weight=1
 ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
 # RESTORE THE DATA DIR
 #=================================================
-ynh_script_progression --message="Restoring the data directory..." --time --weight=2
+ynh_script_progression --message="Restoring the data directory..." --weight=2
 if [ ! -d "$data_path" ]; then
 	if [ $backup_core_only -eq 0 ]; then
 		ynh_restore_file --origin_path="$data_path"
@@ -94,12 +94,12 @@ myynh_set_permissions
 #=================================================
 # RELOAD NGINX AND PHP-FPM
 #=================================================
-ynh_script_progression --message="Reloading nginx web server and php-fpm..." --time --weight=1
+ynh_script_progression --message="Reloading nginx web server and php-fpm..." --weight=1
 ynh_systemd_action --service_name=php7.0-fpm --action=reload
 ynh_systemd_action --service_name=nginx --action=reload
 
 #=================================================
 # END OF SCRIPT
 #=================================================
-ynh_script_progression --message="Restoration completed for $app" --time --last
+ynh_script_progression --message="Restoration completed for $app" --last
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -25,7 +25,7 @@ data_path=$(ynh_app_setting_get --app="$app" --key=data_path)
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================
-ynh_script_progression --message="Ensuring downward compatibility..." --time --weight=1
+ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
 # If final_path doesn't exist, create it
 if [ -z "$final_path" ]; then
 	final_path="/var/www/$app"
@@ -87,7 +87,7 @@ ynh_add_nginx_config
 #=================================================
 # UPGRADE DEPENDENCIES
 #=================================================
-ynh_script_progression --message="Upgrading dependencies..." --time --weight=1
+ynh_script_progression --message="Upgrading dependencies..." --weight=1
 ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================


### PR DESCRIPTION
Moar cleanup because the app is again flagged as level 4 because of package_linter that found an rm -r :s 

I went through other warnings reported by the linter (or other weird / outdated stuff I found along the way) : 
- level instructions and outdated tests that are not relevant anymore in `check_process`
- there's no point checking the disk space in the backup script, this is handled by the core
- no need for `--time` for ynh_script_progression, this is only to calibrate the weight
- backing up the app upon removal is ... interesting ...! I guess we could discuss having this as an option ... but to me this behavior feels weird and could be very surprising to the user because basically no other app does this ?
